### PR TITLE
Format message timestamps for threads

### DIFF
--- a/src/components/MessageItem.tsx
+++ b/src/components/MessageItem.tsx
@@ -12,7 +12,7 @@ export interface DisplayMessage {
 export default function MessageItem({ msg }: { msg: DisplayMessage }) {
 	return (
 		<div className="message">
-			<div className="meta">{msg.from ?? 'unknown'} • {format(new Date(msg.date * 1000), 'yyyy-MM-dd HH:mm')}</div>
+			<div className="meta">{msg.from ?? 'unknown'} • {(() => { const d = new Date(msg.date * 1000); return `${format(d, "d MMMM yyyy 'at' h:mm")}${format(d, 'a').toLowerCase()}`; })()}</div>
 			<div className="body"><MarkdownView text={msg.text} /></div>
 		</div>
 	);

--- a/src/features/forum/ForumPage.tsx
+++ b/src/features/forum/ForumPage.tsx
@@ -6,6 +6,7 @@ import { getInputPeerForForumId } from '@lib/telegram/peers';
 import { TopicItem } from '@components/TopicList';
 import ForumList from '@components/ForumList';
 import { useForumsStore } from '@state/forums';
+import { format } from 'date-fns';
 
 export default function ForumPage() {
 	const { id } = useParams();
@@ -52,7 +53,7 @@ export default function ForumPage() {
 								{(data ?? []).map((t) => (
 									<div key={t.id} className="chiclet" onClick={() => navigate(`/forum/${forumId}/topic/${t.id}`)}>
 										<div className="title">{t.iconEmoji ? `${t.iconEmoji} ` : ''}{t.title}</div>
-										<div className="sub">{t.unreadCount ? `${t.unreadCount} unread • ` : ''}{t.lastActivity ? new Date(t.lastActivity).toLocaleString() : '—'}</div>
+										<div className="sub">{t.unreadCount ? `${t.unreadCount} unread • ` : ''}{t.lastActivity ? `${format(new Date(t.lastActivity), "d MMMM yyyy 'at' h:mm")}${format(new Date(t.lastActivity), 'a').toLowerCase()}` : '—'}</div>
 									</div>
 								))}
 							</div>


### PR DESCRIPTION
Update message and last activity timestamps to "1 January 2026 at 12:13am" format.

---
<a href="https://cursor.com/background-agent?bcId=bc-2e6e8536-a4dd-4b16-befe-81db0cd974f8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2e6e8536-a4dd-4b16-befe-81db0cd974f8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

