### PR TITLE
Format message timestamps for threads

### DIFF
--- a/src/components/MessageItem.tsx
+++ b/src/components/MessageItem.tsx
@@ -12,6 +12,10 @@ export interface DisplayMessage {
 }
 
 export default function MessageItem({ msg }: { msg: DisplayMessage }) {
+	const dateObj = new Date(msg.date * 1000);
+	const datePart = format(dateObj, 'd MMMM yyyy');
+	const timePart = format(dateObj, 'h:mm a').replace(' ', '').toLowerCase();
+	const postedAt = `${datePart} at ${timePart}`;
 	return (
 		<div className="forum-post">
 			<div className="post-author">
@@ -26,7 +30,7 @@ export default function MessageItem({ msg }: { msg: DisplayMessage }) {
 				)}
 			</div>
 			<div className="post-body">
-				<div className="post-meta">Posted {format(new Date(msg.date * 1000), 'yyyy-MM-dd HH:mm')}</div>
+				<div className="post-meta">Posted {postedAt}</div>
 				<div className="post-content"><MarkdownView text={msg.text} /></div>
 			</div>
 		</div>

--- a/src/components/TopicList.tsx
+++ b/src/components/TopicList.tsx
@@ -7,10 +7,24 @@ export default function TopicList({ items, onOpen }: { items: TopicItem[]; onOpe
 				<div className="list-item" key={t.id} onClick={() => onOpen(t.id)}>
 					<div className="col">
 						<div className="title">{t.iconEmoji ? `${t.iconEmoji} ` : ''}{t.title}</div>
-						<div className="sub">{t.unreadCount ? `${t.unreadCount} unread • ` : ''}{t.lastActivity ? new Date(t.lastActivity).toLocaleString() : '—'}</div>
+						<div className="sub">{t.unreadCount ? `${t.unreadCount} unread • ` : ''}{t.lastActivity ? formatTimestamp(t.lastActivity) : '—'}</div>
 					</div>
 				</div>
 			))}
 		</div>
 	);
+}
+
+function formatTimestamp(msSinceEpoch: number): string {
+	const d = new Date(msSinceEpoch);
+	const day = d.getDate();
+	const monthNames = ['January','February','March','April','May','June','July','August','September','October','November','December'];
+	const datePart = `${day} ${monthNames[d.getMonth()]} ${d.getFullYear()}`;
+	let hours = d.getHours();
+	const minutes = d.getMinutes().toString().padStart(2, '0');
+	const ampm = hours >= 12 ? 'pm' : 'am';
+	hours = hours % 12;
+	if (hours === 0) hours = 12;
+	const timePart = `${hours}:${minutes}${ampm}`;
+	return `${datePart} at ${timePart}`;
 }

--- a/src/features/forum/ForumPage.tsx
+++ b/src/features/forum/ForumPage.tsx
@@ -52,7 +52,7 @@ export default function ForumPage() {
 								{(data ?? []).map((t) => (
 									<div key={t.id} className="chiclet" onClick={() => navigate(`/forum/${forumId}/topic/${t.id}`)}>
 										<div className="title">{t.iconEmoji ? `${t.iconEmoji} ` : ''}{t.title}</div>
-										<div className="sub">{t.unreadCount ? `${t.unreadCount} unread • ` : ''}{t.lastActivity ? new Date(t.lastActivity).toLocaleString() : '—'}</div>
+										<div className="sub">{t.unreadCount ? `${t.unreadCount} unread • ` : ''}{t.lastActivity ? formatTimestamp(t.lastActivity) : '—'}</div>
 									</div>
 								))}
 							</div>
@@ -62,4 +62,18 @@ export default function ForumPage() {
 			</main>
 		</div>
 	);
+}
+
+function formatTimestamp(msSinceEpoch: number): string {
+	const d = new Date(msSinceEpoch);
+	const day = d.getDate();
+	const monthNames = ['January','February','March','April','May','June','July','August','September','October','November','December'];
+	const datePart = `${day} ${monthNames[d.getMonth()]} ${d.getFullYear()}`;
+	let hours = d.getHours();
+	const minutes = d.getMinutes().toString().padStart(2, '0');
+	const ampm = hours >= 12 ? 'pm' : 'am';
+	hours = hours % 12;
+	if (hours === 0) hours = 12;
+	const timePart = `${hours}:${minutes}${ampm}`;
+	return `${datePart} at ${timePart}`;
 }


### PR DESCRIPTION
Update timestamp formats across messages and board lists to match the "1 January 2026 at 12:13am" style.

---
<a href="https://cursor.com/background-agent?bcId=bc-84b22162-4bed-4be0-814d-a190e1114e88">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-84b22162-4bed-4be0-814d-a190e1114e88">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

