### PR TITLE
Fix featured forum chiclet auto-height

### DIFF
--- a/src/features/forum/ForumPage.tsx
+++ b/src/features/forum/ForumPage.tsx
@@ -47,7 +47,7 @@ export default function ForumPage() {
 						) : error ? (
 							<div style={{ color: 'var(--danger)' }}>{(error as any)?.message ?? 'Error'}</div>
 						) : (
-							<div className="gallery">
+							<div className="gallery boards">
 								{(data ?? []).map((t) => (
 									<div key={t.id} className="chiclet" onClick={() => navigate(`/forum/${forumId}/topic/${t.id}`)}>
 										<div className="title">{t.title}</div>

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -61,9 +61,12 @@ a:hover { text-decoration: underline; }
 
 /* Gallery */
 .gallery { display: grid; grid-template-columns: repeat(auto-fill, 240px); gap: 12px; justify-content: start; }
-.chiclet { display: flex; flex-direction: column; gap: 6px; padding: 12px; border: 1px solid var(--border); border-radius: 12px; background: #0f1b31; cursor: pointer; box-shadow: var(--shadow); width: 240px; height: 64px; overflow: hidden; }
+.chiclet { display: flex; flex-direction: column; gap: 6px; padding: 12px; border: 1px solid var(--border); border-radius: 12px; background: #0f1b31; cursor: pointer; box-shadow: var(--shadow); width: 240px; overflow: visible; }
 .chiclet:hover { background: #14203a; }
 .chiclet .title { font-weight: 700; }
+
+/* Forum boards use fixed-height chiclets as an exception to the default */
+.gallery.boards .chiclet { height: 64px; overflow: hidden; }
 
 /* Forms */
 .input { width: 100%; padding: 10px 12px; background: #0b1529; border: 1px solid var(--border); border-radius: 10px; color: var(--text); }


### PR DESCRIPTION
Revert default chiclet height to auto and apply fixed height specifically to forum board chiclets.

The previous change to fix forum board chiclet height inadvertently applied the fixed height to all chiclets, including featured forum chiclets which should have an automatically determined height. This PR makes auto-height the default and applies the fixed height as an exception for forum boards.

---
<a href="https://cursor.com/background-agent?bcId=bc-80f7f9aa-9036-48af-be0e-24ec54ed8f33">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-80f7f9aa-9036-48af-be0e-24ec54ed8f33">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

