### PR TITLE
Constrain user info box height to content

### DIFF
--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -100,7 +100,7 @@ a:hover { text-decoration: underline; }
 
 /* Forum-style thread */
 .forum-thread { display: flex; flex-direction: column; gap: 12px; padding: 12px; }
-.forum-post { display: grid; grid-template-columns: 180px 1fr; gap: 12px; padding: 12px; border-bottom: 1px solid var(--border); }
+.forum-post { display: grid; grid-template-columns: 180px 1fr; gap: 12px; padding: 12px; border-bottom: 1px solid var(--border); align-items: start; }
 .post-author { display: flex; flex-direction: column; gap: 8px; align-items: center; justify-content: flex-start; background: #0e1830; border: 1px solid var(--border); border-radius: 10px; padding: 12px; }
 .post-author .avatar { width: 96px; height: 96px; border-radius: 8px; object-fit: cover; border: 1px solid var(--border); background: #0b1529; }
 .post-author .avatar.placeholder { opacity: 0.3; }


### PR DESCRIPTION
Set forum post grid alignment to prevent user info boxes from stretching vertically.

---
<a href="https://cursor.com/background-agent?bcId=bc-072395b9-3dd4-4d4e-8137-5b039dd1af2f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-072395b9-3dd4-4d4e-8137-5b039dd1af2f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

