### PR TITLE
Add forumgram color themes to settings

### DIFF
--- a/src/features/forum/TopicPage.tsx
+++ b/src/features/forum/TopicPage.tsx
@@ -167,16 +167,6 @@ export default function TopicPage() {
 				};
 			});
 			const displaySource: any[] = [...singles, ...aggregated];
-			const display = mapped.map((m: any) => ({
-				id: m.id,
-				from: m.from,
-				date: m.date,
-				text: m.text,
-				threadId: m.threadId,
-				avatarUrl: m.avatarUrl,
-				activityCount: m.fromUserId ? activityMap[m.fromUserId] : undefined,
-				attachments: m.attachments,
-			}));
 			// Use combined list for display
 			const displayCombined = displaySource.map((m: any) => ({
 				id: m.id,

--- a/src/features/settings/SettingsPage.tsx
+++ b/src/features/settings/SettingsPage.tsx
@@ -1,7 +1,7 @@
 import { useSettingsStore } from '@state/settings';
 
 export default function SettingsPage() {
-	const { markdownEnabled, katexEnabled, forumSecret, setMarkdown, setKatex, setForumSecret } = useSettingsStore();
+	const { markdownEnabled, katexEnabled, forumSecret, theme, setMarkdown, setKatex, setForumSecret, setTheme } = useSettingsStore();
 	return (
 		<div className="content" style={{ gridTemplateColumns: '1fr' }}>
 			<main className="main">
@@ -16,6 +16,15 @@ export default function SettingsPage() {
 							<input type="checkbox" checked={katexEnabled} onChange={(e) => setKatex(e.target.checked)} />
 							<span>Enable KaTeX</span>
 						</label>
+						<div className="field">
+							<label className="label">Theme</label>
+							<select className="input" value={theme} onChange={(e) => setTheme(e.target.value as any)}>
+								<option value="midnight">Midnight</option>
+								<option value="light">Light</option>
+								<option value="monokai">Monokai</option>
+								<option value="catpuccin">Catpuccin</option>
+							</select>
+						</div>
 						<div className="field">
 							<label className="label">Forum Secret (for thread tag verification)</label>
 							<input className="input" value={forumSecret ?? ''} onChange={(e) => setForumSecret(e.target.value || null)} placeholder="Optional" />

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,7 @@ import App from './app/App';
 import '@styles/theme.css';
 import { registerSW } from 'virtual:pwa-register';
 import { useForumsStore } from '@state/forums';
+import { useSettingsStore } from '@state/settings';
 
 const queryClient = new QueryClient({
 	defaultOptions: {
@@ -20,6 +21,17 @@ registerSW({ immediate: true });
 
 // Hydrate forums from localStorage on startup so the sidebar has recent forums
 try { useForumsStore.getState().initFromStorage(); } catch {}
+// Hydrate settings (theme) from localStorage and apply to document
+try {
+    const settings = useSettingsStore.getState();
+    settings.initFromStorage();
+    const applyTheme = (theme: typeof settings.theme) => {
+        document.documentElement.setAttribute('data-theme', theme);
+    };
+    applyTheme(settings.theme);
+    // subscribe to changes so switching themes updates immediately
+    useSettingsStore.subscribe((s) => applyTheme(s.theme));
+} catch {}
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
 	<StrictMode>

--- a/src/state/settings.ts
+++ b/src/state/settings.ts
@@ -4,18 +4,34 @@ interface SettingsState {
 	markdownEnabled: boolean;
 	katexEnabled: boolean;
 	forumSecret: string | null;
-	theme: 'dark';
+	theme: 'midnight' | 'light' | 'monokai' | 'catpuccin';
 	setMarkdown: (on: boolean) => void;
 	setKatex: (on: boolean) => void;
 	setForumSecret: (secret: string | null) => void;
+	setTheme: (theme: SettingsState['theme']) => void;
+	initFromStorage: () => void;
 }
+
+const THEME_KEY = 'fg_theme_v1';
 
 export const useSettingsStore = create<SettingsState>((set) => ({
 	markdownEnabled: true,
 	katexEnabled: true,
 	forumSecret: null,
-	theme: 'dark',
+	theme: 'midnight',
 	setMarkdown: (on) => set({ markdownEnabled: on }),
 	setKatex: (on) => set({ katexEnabled: on }),
 	setForumSecret: (secret) => set({ forumSecret: secret }),
+	setTheme: (theme) => {
+		try { localStorage.setItem(THEME_KEY, theme); } catch {}
+		set({ theme });
+	},
+	initFromStorage: () => {
+		try {
+			const stored = localStorage.getItem(THEME_KEY) as SettingsState['theme'] | null;
+			if (stored) {
+				set({ theme: stored });
+			}
+		} catch {}
+	},
 }));

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,5 +1,6 @@
 /* Theme variables */
-:root {
+:root,
+:root[data-theme="midnight"] {
 	--bg: #0b1220;
 	--bg-elev: #0f172a;
 	--panel: #0f1b31;
@@ -11,6 +12,51 @@
 	--success: #10b981;
 	--border: #1f2a44;
 	--shadow: 0 8px 24px rgba(2, 6, 23, 0.4);
+}
+
+/* Light */
+:root[data-theme="light"] {
+	--bg: #f8fafc;
+	--bg-elev: #ffffff;
+	--panel: #ffffff;
+	--text: #0f172a;
+	--muted: #475569;
+	--accent: #2563eb;
+	--accent-2: #60a5fa;
+	--danger: #dc2626;
+	--success: #16a34a;
+	--border: #e2e8f0;
+	--shadow: 0 8px 24px rgba(2, 6, 23, 0.08);
+}
+
+/* Monokai */
+:root[data-theme="monokai"] {
+	--bg: #272822;
+	--bg-elev: #2d2f26;
+	--panel: #32342b;
+	--text: #f8f8f2;
+	--muted: #a6e22e;
+	--accent: #66d9ef;
+	--accent-2: #a6e22e;
+	--danger: #f92672;
+	--success: #a6e22e;
+	--border: #3e4236;
+	--shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+}
+
+/* Catpuccin (Mocha-inspired) */
+:root[data-theme="catpuccin"] {
+	--bg: #1e1e2e;
+	--bg-elev: #181825;
+	--panel: #11111b;
+	--text: #cdd6f4;
+	--muted: #a6adc8;
+	--accent: #89b4fa;
+	--accent-2: #b4befe;
+	--danger: #f38ba8;
+	--success: #a6e3a1;
+	--border: #313244;
+	--shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
 }
 
 * { box-sizing: border-box; }


### PR DESCRIPTION
Add theme selection to the Settings menu with Midnight, Light, Monokai, and Catpuccin options.

---
<a href="https://cursor.com/background-agent?bcId=bc-88816cdc-597c-4dee-bc4e-8851c19e8667">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-88816cdc-597c-4dee-bc4e-8851c19e8667">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

