### PR TITLE
Escape and unescape markdown for telegram compatibility

### DIFF
--- a/src/features/forum/BoardPage.tsx
+++ b/src/features/forum/BoardPage.tsx
@@ -5,6 +5,7 @@ import { useForumsStore } from '@state/forums';
 import { getInputPeerForForumId } from '@lib/telegram/peers';
 import { useQuery } from '@tanstack/react-query';
 import { ThreadMeta, searchThreadCards, searchPostCards, composeThreadCard, composePostCard, generateIdHash, searchBoardCards } from '@lib/protocol';
+import { unescapeMarkdownFromTelegram } from '@lib/markdownEscape';
 import { deleteMessages, sendPlainMessage, getClient, editMessage } from '@lib/telegram/client';
 import MessageList from '@components/MessageList';
 import { getAvatarBlob, setAvatarBlob } from '@lib/db';
@@ -94,7 +95,7 @@ export default function BoardPage() {
 				id: p.messageId,
 				from: p.fromUserId ? (p.user?.username ? '@' + p.user.username : [p.user?.firstName, p.user?.lastName].filter(Boolean).join(' ')) : 'unknown',
 				date: p.date ?? 0,
-				text: p.content,
+				text: unescapeMarkdownFromTelegram(p.content),
 				threadId: p.parentThreadId,
 				avatarUrl: p.fromUserId ? userIdToUrl[p.fromUserId] : undefined,
 				attachments: (p as any).media ? [{ name: 'attachment', isMedia: true, media: (p as any).media }] : [],

--- a/src/lib/markdownEscape.ts
+++ b/src/lib/markdownEscape.ts
@@ -1,0 +1,70 @@
+// Utilities to escape and unescape Markdown characters so Telegram doesn't strip them
+
+// Telegram MarkdownV2 special characters
+const TELEGRAM_MD_CHARS = '_*[]()~`>#+-=|{}.!';
+
+function isTelegramMdChar(ch: string): boolean {
+  return TELEGRAM_MD_CHARS.includes(ch);
+}
+
+/**
+ * Prefix Telegram Markdown special characters with a backslash when not already escaped
+ * by an odd number of preceding backslashes.
+ */
+export function escapeMarkdownForTelegram(input: string): string {
+  if (!input) return input;
+  let result = '';
+  for (let index = 0; index < input.length; index++) {
+    const character = input[index];
+    if (isTelegramMdChar(character)) {
+      // Count consecutive backslashes immediately before this character
+      let backslashCount = 0;
+      let lookbackIndex = index - 1;
+      while (lookbackIndex >= 0 && input[lookbackIndex] === '\\') {
+        backslashCount++;
+        lookbackIndex--;
+      }
+      if (backslashCount % 2 === 0) {
+        // Even number of preceding backslashes means it's not escaped yet
+        result += '\\' + character;
+      } else {
+        // Already escaped by user input
+        result += character;
+      }
+    } else {
+      result += character;
+    }
+  }
+  return result;
+}
+
+/**
+ * Remove a single escaping backslash before Telegram Markdown characters when that backslash
+ * is not itself escaped by an odd number of preceding backslashes.
+ */
+export function unescapeMarkdownFromTelegram(input: string): string {
+  if (!input) return input;
+  let result = '';
+  for (let index = 0; index < input.length; index++) {
+    const character = input[index];
+    if (
+      character === '\\' &&
+      index + 1 < input.length &&
+      isTelegramMdChar(input[index + 1])
+    ) {
+      // Count consecutive backslashes immediately before this backslash
+      let backslashCount = 0;
+      let lookbackIndex = index - 1;
+      while (lookbackIndex >= 0 && input[lookbackIndex] === '\\') {
+        backslashCount++;
+        lookbackIndex--;
+      }
+      if (backslashCount % 2 === 0) {
+        // This is our escaping backslash – drop it and let the next character be appended by loop
+        continue;
+      }
+    }
+    result += character;
+  }
+  return result;
+}

--- a/src/lib/markdownEscape.ts
+++ b/src/lib/markdownEscape.ts
@@ -1,7 +1,7 @@
 // Utilities to escape and unescape Markdown characters so Telegram doesn't strip them
 
-// Telegram MarkdownV2 special characters
-const TELEGRAM_MD_CHARS = '_*[]()~`>#+-=|{}.!';
+// Telegram MarkdownV2 special characters plus '"' to avoid issues in JSON contexts
+const TELEGRAM_MD_CHARS = '_*[]()~`>#+-=|{}.!"';
 
 function isTelegramMdChar(ch: string): boolean {
   return TELEGRAM_MD_CHARS.includes(ch);

--- a/src/lib/protocol.ts
+++ b/src/lib/protocol.ts
@@ -1,5 +1,6 @@
 import { Api } from 'telegram';
 import { getClient } from '@lib/telegram/client';
+import { escapeMarkdownForTelegram } from '@lib/markdownEscape';
 
 export interface BoardMeta {
 	// Permanent ID (hash)
@@ -90,7 +91,7 @@ export function parseThreadCard(text: string): { id: string; parentBoardId: stri
 }
 
 export function composePostCard(id: string, parentThreadId: string, data: { content: string }): string {
-	const payload = JSON.stringify({ content: data.content });
+	const payload = JSON.stringify({ content: escapeMarkdownForTelegram(data.content) });
 	return `fg.post\n${id}\nparent:${parentThreadId}\n${payload}`;
 }
 
@@ -250,4 +251,3 @@ export async function searchPostCards(input: Api.TypeInputPeer, parentThreadId: 
 
 	return items;
 }
-


### PR DESCRIPTION
Escape and unescape Markdown special characters to preserve post formatting when sent via Telegram and displayed in ForumGram.

---
<a href="https://cursor.com/background-agent?bcId=bc-d8de7fcd-e841-4382-91f2-137565a97639">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d8de7fcd-e841-4382-91f2-137565a97639">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

