### PR TITLE
Allow joining private telegram groups via invite links

### DIFF
--- a/src/features/catalog/DiscoverPage.tsx
+++ b/src/features/catalog/DiscoverPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { resolveForum } from '@lib/telegram/client';
+import { resolveForum, joinInviteLink } from '@lib/telegram/client';
 import { useForumsStore } from '@state/forums';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import ForumList from '@components/ForumList';
@@ -12,6 +12,7 @@ export default function DiscoverPage() {
 	const [result, setResult] = useState<any | null>(null);
 	const [error, setError] = useState<string | null>(null);
 	const [loading, setLoading] = useState(false);
+	const [isInvitePreview, setIsInvitePreview] = useState(false);
 	const addOrUpdateForum = useForumsStore((s) => s.addOrUpdateForum);
 	const initForums = useForumsStore((s) => s.initFromStorage);
 	const navigate = useNavigate();
@@ -25,16 +26,22 @@ export default function DiscoverPage() {
 		try {
 			setLoading(true);
 			setError(null);
+			setIsInvitePreview(false);
 			const input = query.trim();
-			const handle = input.startsWith('@') ? input.slice(1) : input;
-			const res: any = await resolveForum('@' + handle);
+			const normalized = (input.startsWith('@') || input.includes('t.me') || input.includes('telegram.me')) ? input : ('@' + input);
+			const res: any = await resolveForum(normalized);
 			setResult(res);
-			// Attempt to locate chat/channel info.
-			const channel = (res.chats ?? []).find((c: any) => c.className === 'Channel' || c._ === 'channel' || c._ === 'Channel');
-			const chat = (res.chats ?? []).find((c: any) => c.className === 'Chat' || c._ === 'chat');
+			// Determine if this is an invite preview or a resolved username
+			const isInvite = Boolean((res?._ ?? res?.className)?.toString().toLowerCase().includes('chatinvite')) && !((res?._ ?? res?.className)?.toString().toLowerCase().includes('already'));
+			setIsInvitePreview(isInvite);
+			// If we have chats, we can cache basic meta immediately
+			const channel = (res?.chats ?? []).find((c: any) => c.className === 'Channel' || c._ === 'channel' || c._ === 'Channel');
+			const chat = (res?.chats ?? []).find((c: any) => c.className === 'Chat' || c._ === 'chat');
 			if (channel) {
+				const handle = input.startsWith('@') ? input.slice(1) : (input.includes('t.me') ? undefined : input);
 				addOrUpdateForum({ id: Number(channel.id), title: channel.title, username: handle, accessHash: channel.accessHash, isForum: Boolean(channel.forum), isPublic: Boolean(channel.username) });
 			} else if (chat) {
+				const handle = input.startsWith('@') ? input.slice(1) : (input.includes('t.me') ? undefined : input);
 				addOrUpdateForum({ id: Number(chat.id), title: chat.title, username: handle, accessHash: undefined, isForum: false, isPublic: Boolean(handle) });
 			}
 		} catch (e: any) {
@@ -46,11 +53,35 @@ export default function DiscoverPage() {
 		try {
 			const channel = (result?.chats ?? []).find((c: any) => c.className === 'Channel' || c._ === 'channel' || c._ === 'Channel');
 			const chat = (result?.chats ?? []).find((c: any) => c.className === 'Chat' || c._ === 'chat');
-			const id = channel ? Number(channel.id) : (chat ? Number(chat.id) : null);
+			// Some invite responses (ChatInviteAlready) return a single chat object directly
+			const directChat = (!channel && !chat && (result?.chat)) ? result.chat : null;
+			const id = channel ? Number(channel.id) : (chat ? Number(chat.id) : (directChat ? Number(directChat.id) : null));
 			if (!id) throw new Error('No suitable chat in result');
 			navigate(`/forum/${id}`);
 		} catch (e: any) {
 			setError(e?.message ?? 'Cannot open forum');
+		}
+	}
+
+	async function onJoin() {
+		try {
+			setLoading(true);
+			setError(null);
+			const updates: any = await joinInviteLink(query.trim());
+			const channel = (updates?.chats ?? []).find((c: any) => c.className === 'Channel' || c._ === 'channel' || c._ === 'Channel');
+			const chat = (updates?.chats ?? []).find((c: any) => c.className === 'Chat' || c._ === 'chat');
+			const id = channel ? Number(channel.id) : (chat ? Number(chat.id) : null);
+			if (!id) throw new Error('Joined, but no chat found in updates');
+			if (channel) {
+				addOrUpdateForum({ id, title: channel.title, username: channel.username, accessHash: channel.accessHash, isForum: Boolean(channel.forum), isPublic: Boolean(channel.username) });
+			} else if (chat) {
+				addOrUpdateForum({ id, title: chat.title, username: chat.username, accessHash: undefined, isForum: false, isPublic: Boolean(chat.username) });
+			}
+			navigate(`/forum/${id}`);
+		} catch (e: any) {
+			setError(e?.message ?? 'Failed to join invite link');
+		} finally {
+			setLoading(false);
 		}
 	}
 
@@ -93,7 +124,7 @@ export default function DiscoverPage() {
 							<div className="field">
 								<label className="label">Forum handle or invite</label>
 								<div className="form-row">
-									<input className="input" placeholder="@my_forum" value={query} onChange={(e) => setQuery(e.target.value)} />
+									<input className="input" placeholder="@my_forum or https://t.me/+hash" value={query} onChange={(e) => setQuery(e.target.value)} />
 									<button className="btn primary" onClick={onResolve} disabled={!query || loading}>Resolve</button>
 								</div>
 							</div>
@@ -101,7 +132,13 @@ export default function DiscoverPage() {
 							{result && (
 								<div className="col" style={{ marginTop: 8 }}>
 									<pre style={{ overflow: 'auto', maxHeight: 320 }}>{JSON.stringify(result, null, 2)}</pre>
-									<button className="btn" onClick={onOpen}>Open forum</button>
+									<div className="form-row">
+										{isInvitePreview ? (
+											<button className="btn primary" onClick={onJoin} disabled={loading}>Join forum</button>
+										) : (
+											<button className="btn" onClick={onOpen}>Open forum</button>
+										)}
+									</div>
 								</div>
 							)}
 						</div>

--- a/src/features/forum/BoardPage.tsx
+++ b/src/features/forum/BoardPage.tsx
@@ -73,7 +73,7 @@ export default function BoardPage() {
 		staleTime: 10_000,
 	});
 
-	const { data: lastPostByThreadId = {}, isLoading: loadingThreadLastPosts } = useQuery<{ [threadId: string]: any }>({
+	const { data: lastPostByThreadId = {} } = useQuery<{ [threadId: string]: any }>({
 		queryKey: ['last-post-by-thread', forumId, boardId, (threads ?? []).map((t) => t.id)],
 		queryFn: async () => {
 			const input = getInputPeerForForumId(forumId);

--- a/src/features/forum/ForumPage.tsx
+++ b/src/features/forum/ForumPage.tsx
@@ -31,7 +31,7 @@ export default function ForumPage() {
 		enabled: Number.isFinite(forumId),
 	});
 
-	const { data: lastPostByBoardId = {}, isLoading: loadingLastPosts } = useQuery<{ [boardId: string]: any }>({
+	const { data: lastPostByBoardId = {} } = useQuery<{ [boardId: string]: any }>({
 		queryKey: ['last-post-by-board', forumId, (data ?? []).map((b) => b.id)],
 		queryFn: async () => {
 			const input = getInputPeerForForumId(forumId);


### PR DESCRIPTION
Add support for joining Telegram forums using invite links (e.g., `t.me/+HASH` and `t.me/joinchat/HASH`).

---
<a href="https://cursor.com/background-agent?bcId=bc-287cbf95-1434-4953-8853-3e2861a1f1f5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-287cbf95-1434-4953-8853-3e2861a1f1f5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

