### PR TITLE
Fix monokai dimmed link colors

### DIFF
--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -12,6 +12,9 @@
 	--border: #1f2a44;
 	--shadow: 0 8px 24px rgba(2, 6, 23, 0.4);
 
+	/* Links default to accent unless overridden by theme */
+	--link: var(--accent);
+
 	/* Extended surfaces */
 	--header-grad-top: #0f1b31;
 	--header-grad-bottom: #0b1220;
@@ -52,6 +55,9 @@ html[data-theme="monokai-dimmed"] {
 	--success: #A6E22E;
 	--border: #3a3a3a;
 	--shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+
+	/* Use Monokai constant color for links */
+	--link: #AE81FF;
 
 	--header-grad-top: #2a2a2a;
 	--header-grad-bottom: #1e1e1e;
@@ -144,7 +150,7 @@ html[data-theme="telegram-light"] {
 html, body, #root { height: 100%; }
 html, body { margin: 0; background: var(--bg); color: var(--text); font: 14px/1.5 system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Arial, "Apple Color Emoji", "Segoe UI Emoji"; }
 
-a { color: var(--accent); text-decoration: none; }
+a { color: var(--link, var(--accent)); text-decoration: none; }
 a:hover { text-decoration: underline; }
 
 /* Layout */

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -56,8 +56,8 @@ html[data-theme="monokai-dimmed"] {
 	--border: #3a3a3a;
 	--shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
 
-	/* Use Monokai constant color for links */
-	--link: #AE81FF;
+	/* Link color */
+	--link: #6089B4;
 
 	--header-grad-top: #2a2a2a;
 	--header-grad-bottom: #1e1e1e;


### PR DESCRIPTION
Set Monokai Dimmed theme link color to its 'constant' palette color.

The previous blue link color was inconsistent with the Monokai Dimmed theme's intended palette. A new `--link` CSS variable is introduced to allow themes to define their link color, with a fallback to `--accent` for other themes.

---
<a href="https://cursor.com/background-agent?bcId=bc-8f042b83-1cb7-43d3-82a6-a0bfe092dc8a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8f042b83-1cb7-43d3-82a6-a0bfe092dc8a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

