### PR TITLE
Implement forum thread pagination with navigation

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -52,6 +52,7 @@ export default function App() {
 				<Route path="/forum/:id" element={<RequireAuth><ForumPage /></RequireAuth>} />
 				<Route path="/forum/:id/board/:boardId" element={<RequireAuth><BoardPage /></RequireAuth>} />
 				<Route path="/forum/:id/board/:boardId/thread/:threadId" element={<RequireAuth><BoardPage /></RequireAuth>} />
+				<Route path="/forum/:id/board/:boardId/thread/:threadId/page/:page" element={<RequireAuth><BoardPage /></RequireAuth>} />
 				<Route path="/settings" element={<RequireAuth><SettingsPage /></RequireAuth>} />
 				<Route path="*" element={<RequireAuth><DiscoverPage /></RequireAuth>} />
 			</Routes>


### PR DESCRIPTION
Adds pagination to forum threads to improve performance and user experience by loading only 20 posts per page.

This change introduces server-side pagination, fetching only the posts for the current page from Telegram, making thread viewing faster and more efficient. It also makes thread pages directly linkable via URL, with "First", "Previous", "Next", and "Last" buttons for navigation.

---
<a href="https://cursor.com/background-agent?bcId=bc-063c7303-88ef-4b3c-af33-5363b801e7cc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-063c7303-88ef-4b3c-af33-5363b801e7cc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

