### PR TITLE
Display forum profile photo in multiple locations

### DIFF
--- a/src/components/ForumAvatar.tsx
+++ b/src/components/ForumAvatar.tsx
@@ -1,0 +1,103 @@
+import { CSSProperties, useEffect, useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { getClient } from '@lib/telegram/client';
+import { getInputPeerForForumId } from '@lib/telegram/peers';
+
+type ForumAvatarProps = {
+\tforumId?: number;
+\tusername?: string; // without leading @ preferred, but @ is tolerated
+\tsize?: number; // pixels
+\tclassName?: string;
+\ttitle?: string; // used for fallback initial
+\tstyle?: CSSProperties;
+};
+
+export default function ForumAvatar({ forumId, username, size = 32, className, title, style }: ForumAvatarProps) {
+\tconst normalizedHandle = useMemo(() => {
+\t\tif (!username) return undefined;
+\t\tconst s = username.trim();
+\t\treturn s.startsWith('@') ? s.slice(1) : s;
+\t}, [username]);
+
+\tconst { data: blob, isFetching } = useQuery<Blob | null>({
+\t\tqueryKey: forumId ? ['forum-avatar', forumId] : ['forum-avatar-handle', normalizedHandle ?? ''],
+\t\tqueryFn: async () => {
+\t\t\ttry {
+\t\t\t\tconst client = await getClient();
+\t\t\t\tlet entity: any = null;
+\t\t\t\tif (typeof forumId === 'number') {
+\t\t\t\t\tconst input = getInputPeerForForumId(forumId);
+\t\t\t\t\ttry { entity = await (client as any).getEntity(input as any); } catch {}
+\t\t\t\t} else if (normalizedHandle) {
+\t\t\t\t\ttry { entity = await (client as any).getEntity(normalizedHandle); } catch {}
+\t\t\t\t}
+\t\t\t\tif (!entity) return null;
+\t\t\t\ttry {
+\t\t\t\t\tconst data: any = await (client as any).downloadProfilePhoto(entity);
+\t\t\t\t\tif (!data) return null;
+\t\t\t\t\treturn data instanceof Blob ? data : new Blob([data]);
+\t\t\t\t} catch {
+\t\t\t\t\treturn null;
+\t\t\t\t}
+\t\t\t} catch {
+\t\t\t\treturn null;
+\t\t\t}
+\t\t},
+\t\tenabled: Boolean((typeof forumId === 'number' && forumId) || normalizedHandle),
+\t\tstaleTime: 5 * 60 * 1000,
+\t\tgcTime: 10 * 60 * 1000,
+\t});
+
+\tconst [objectUrl, setObjectUrl] = useState<string | null>(null);
+\tuseEffect(() => {
+\t\tif (!blob) {
+\t\t\tsetObjectUrl((prev) => {
+\t\t\t\tif (prev) URL.revokeObjectURL(prev);
+\t\t\t\treturn null;
+\t\t\t});
+\t\t\treturn;
+\t\t}
+\t\tconst url = URL.createObjectURL(blob);
+\t\tsetObjectUrl((prev) => {
+\t\t\tif (prev) URL.revokeObjectURL(prev);
+\t\t\treturn url;
+\t\t});
+\t\treturn () => { URL.revokeObjectURL(url); };
+\t}, [blob]);
+
+\tconst fallbackInitial = useMemo(() => {
+\t\tconst base = title || normalizedHandle || (typeof forumId === 'number' ? String(forumId) : '');
+\t\tconst ch = (base || '').trim().charAt(0).toUpperCase();
+\t\treturn ch || '?';
+\t}, [title, normalizedHandle, forumId]);
+
+\treturn (
+\t\t<div
+\t\t\tclassName={className}
+\t\t\tstyle={{
+\t\t\t\twidth: size,
+\t\t\t\theight: size,
+\t\t\t\tborderRadius: size / 2,
+\t\t\t\toverflow: 'hidden',
+\t\t\t\tbackground: 'linear-gradient(135deg, #1e293b, #0b1220)',
+\t\t\t\tdisplay: 'inline-flex',
+\t\t\t\talignItems: 'center',
+\t\t\t\tjustifyContent: 'center',
+\t\t\t\tborder: '1px solid var(--border)',
+\t\t\t\tflex: '0 0 auto',
+\t\t\t\tuserSelect: 'none',
+\t\t\t\t...style,
+\t\t\t}}
+\t\t\ttitle={title || (normalizedHandle ? `@${normalizedHandle}` : undefined)}
+\t\t>
+\t\t\t{objectUrl ? (
+\t\t\t\t<img src={objectUrl} alt="avatar" style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+\t\t\t) : (
+\t\t\t\t<span style={{ fontSize: Math.max(10, Math.floor(size * 0.45)), color: 'var(--muted)' }}>
+\t\t\t\t\t{isFetching ? ' ' : fallbackInitial}
+\t\t\t\t</span>
+\t\t\t)}
+\t\t</div>
+\t);
+}
+

--- a/src/components/ForumList.tsx
+++ b/src/components/ForumList.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useForumsStore } from '@state/forums';
+import ForumAvatar from '@components/ForumAvatar';
 
 export default function ForumList() {
 	const forums = useForumsStore((s) => s.forums);
@@ -41,7 +42,8 @@ export default function ForumList() {
 			</div>
 			<div className="list">
 				{items.map((f) => (
-					<div className="list-item" key={f.id} onClick={() => navigate(`/forum/${f.id}`)} style={{ position: 'relative' }}>
+					<div className="list-item" key={f.id} onClick={() => navigate(`/forum/${f.id}`)} style={{ position: 'relative', alignItems: 'center', display: 'flex', gap: 10 }}>
+						<ForumAvatar forumId={f.id} username={f.username} size={28} title={f.title ?? (f.username ? `@${f.username}` : `Forum ${f.id}`)} />
 						<div className="col">
 							<div className="title">{f.title ?? (f.username ? `@${f.username}` : `Forum ${f.id}`)}</div>
 							<div className="sub">{f.isPublic ? 'Public' : 'Private'}{f.username ? ` • @${f.username}` : ''}</div>

--- a/src/features/catalog/FeaturedForums.tsx
+++ b/src/features/catalog/FeaturedForums.tsx
@@ -1,4 +1,5 @@
 import featured from './featured-forums.json';
+import ForumAvatar from '@components/ForumAvatar';
 
 interface FeaturedForum { address: string; name: string; description: string; }
 
@@ -9,10 +10,13 @@ export default function FeaturedForums({ onSelect }: { onSelect: (address: strin
 			<h4>Featured forums</h4>
 			<div className="gallery">
 				{items.map((f) => (
-					<div key={f.address} className="chiclet" onClick={() => onSelect(f.address)}>
-						<div className="title">{f.name}</div>
-						<div className="sub">{f.address}</div>
-						<p style={{ margin: 0 }}>{f.description}</p>
+					<div key={f.address} className="chiclet" onClick={() => onSelect(f.address)} style={{ display: 'grid', gridTemplateColumns: '40px 1fr', gap: 10, alignItems: 'center' }}>
+						<ForumAvatar username={f.address} size={36} title={f.name} />
+						<div className="col">
+							<div className="title">{f.name}</div>
+							<div className="sub">{f.address}</div>
+							<p style={{ margin: 0 }}>{f.description}</p>
+						</div>
 					</div>
 				))}
 			</div>

--- a/src/features/forum/BoardPage.tsx
+++ b/src/features/forum/BoardPage.tsx
@@ -13,6 +13,7 @@ import { Api } from 'telegram';
 import { useUiStore } from '@state/ui';
 import SidebarToggle from '@components/SidebarToggle';
 import { formatTimeSince } from '@lib/time';
+import ForumAvatar from '@components/ForumAvatar';
 
 export default function BoardPage() {
 	const { id, boardId, threadId } = useParams();
@@ -425,7 +426,8 @@ export default function BoardPage() {
 			<main className="main">
 				{!activeThreadId ? (
 					<div className="card" style={{ padding: 12 }}>
-						<div className="row" style={{ alignItems: 'center' }}>
+						<div className="row" style={{ alignItems: 'center', gap: 10 }}>
+							<ForumAvatar forumId={forumId} username={forumMeta?.username} size={34} title={forumTitle} />
 							<h3 style={{ margin: 0 }}>
 								<Link to={`/forum/${forumId}`}>{forumTitle}</Link>
 								{' > '}
@@ -471,15 +473,15 @@ export default function BoardPage() {
 												</div>
 											)}
 										</div>
-									</div>
-								))}
+									))}
 							</div>
 						)}
 					</div>
 				) : (
 					<div className="card" style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
 						<div style={{ padding: 12, borderBottom: '1px solid var(--border)' }}>
-							<div className="row" style={{ alignItems: 'center' }}>
+							<div className="row" style={{ alignItems: 'center', gap: 10 }}>
+								<ForumAvatar forumId={forumId} username={forumMeta?.username} size={30} title={forumTitle} />
 								<h3 style={{ margin: 0 }}>
 									<Link to={`/forum/${forumId}`}>{forumTitle}</Link>
 									{' > '}

--- a/src/features/forum/ForumPage.tsx
+++ b/src/features/forum/ForumPage.tsx
@@ -9,6 +9,7 @@ import { sendPlainMessage, deleteMessages } from '@lib/telegram/client';
 import { useUiStore } from '@state/ui';
 import SidebarToggle from '@components/SidebarToggle';
 import { formatTimeSince } from '@lib/time';
+import ForumAvatar from '@components/ForumAvatar';
 
 export default function ForumPage() {
 	const { id } = useParams();
@@ -104,7 +105,10 @@ export default function ForumPage() {
 			<SidebarToggle />
 			<main className="main">
 				<div className="card" style={{ padding: 12 }}>
-					<h3>{forumMeta?.title ?? (forumMeta?.username ? `@${forumMeta.username}` : `Forum ${forumId}`)}</h3>
+					<div className="row" style={{ alignItems: 'center', gap: 12 }}>
+						<ForumAvatar forumId={forumId} username={forumMeta?.username} size={40} title={forumMeta?.title ?? (forumMeta?.username ? `@${forumMeta.username}` : `Forum ${forumId}`)} />
+						<h3 style={{ margin: 0 }}>{forumMeta?.title ?? (forumMeta?.username ? `@${forumMeta.username}` : `Forum ${forumId}`)}</h3>
+					</div>
 					<div className="col">
 						<div className="row" style={{ alignItems: 'center' }}>
 							<h4 style={{ marginTop: 0, marginBottom: 0 }}>Boards</h4>


### PR DESCRIPTION
Add forum profile photos to forum listings, featured forums, forum home pages, and board/thread breadcrumbs to enhance UI and visual identification.

---
<a href="https://cursor.com/background-agent?bcId=bc-97d216f3-4bf5-417b-a9cd-e8e48fdf0369">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-97d216f3-4bf5-417b-a9cd-e8e48fdf0369">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

