### PR TITLE
Display forum profile photo in multiple locations

### DIFF
--- a/src/components/ForumAvatar.tsx
+++ b/src/components/ForumAvatar.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
+import { getClient } from '@lib/telegram/client';
+import { getInputPeerForForumId } from '@lib/telegram/peers';
+
+type ForumAvatarProps = {
+	forumId?: number;
+	address?: string; // e.g. "@my_forum"
+	size?: number;
+	alt?: string;
+	className?: string;
+	style?: CSSProperties;
+};
+
+const inMemoryUrlCacheByForumId: Map<number, string> = new Map();
+const inMemoryUrlCacheByHandle: Map<string, string> = new Map();
+
+export default function ForumAvatar(props: ForumAvatarProps) {
+	const { forumId, address, size = 28, alt, className, style } = props;
+	const [url, setUrl] = useState<string | null>(null);
+	const cleanupUrlRef = useRef<string | null>(null);
+
+	const normalizedHandle = useMemo(() => {
+		if (!address) return undefined;
+		return address.startsWith('@') ? address.slice(1) : address;
+	}, [address]);
+
+	useEffect(() => {
+		let canceled = false;
+		(async () => {
+			try {
+				if (typeof forumId === 'number') {
+					const cached = inMemoryUrlCacheByForumId.get(forumId);
+					if (cached) { setUrl(cached); return; }
+					const client = await getClient();
+					let entity: any = null;
+					try {
+						const input = getInputPeerForForumId(forumId);
+						entity = await (client as any).getEntity(input);
+					} catch {}
+					if (!entity) { setUrl(null); return; }
+					try {
+						const data: any = await (client as any).downloadProfilePhoto(entity);
+						if (!data) { setUrl(null); return; }
+						const blob = data instanceof Blob ? data : new Blob([data]);
+						const objectUrl = URL.createObjectURL(blob);
+						inMemoryUrlCacheByForumId.set(forumId, objectUrl);
+						cleanupUrlRef.current = objectUrl;
+						if (!canceled) setUrl(objectUrl);
+					} catch {
+						setUrl(null);
+					}
+					return;
+				}
+
+				if (normalizedHandle) {
+					const cacheKey = normalizedHandle.toLowerCase();
+					const cached = inMemoryUrlCacheByHandle.get(cacheKey);
+					if (cached) { setUrl(cached); return; }
+					const client = await getClient();
+					let entity: any = null;
+					try {
+						const res: any = await client.invoke(new (await import('telegram')).Api.contacts.ResolveUsername({ username: normalizedHandle } as any));
+						const channel = (res?.chats ?? []).find((c: any) => c.className === 'Channel' || c._ === 'channel' || c._ === 'Channel');
+						const chat = (res?.chats ?? []).find((c: any) => c.className === 'Chat' || c._ === 'chat');
+						entity = channel || chat || null;
+					} catch {}
+					if (!entity) { setUrl(null); return; }
+					try {
+						const data: any = await (client as any).downloadProfilePhoto(entity);
+						if (!data) { setUrl(null); return; }
+						const blob = data instanceof Blob ? data : new Blob([data]);
+						const objectUrl = URL.createObjectURL(blob);
+						inMemoryUrlCacheByHandle.set(cacheKey, objectUrl);
+						cleanupUrlRef.current = objectUrl;
+						if (!canceled) setUrl(objectUrl);
+					} catch {
+						setUrl(null);
+					}
+				}
+			} catch {
+				setUrl(null);
+			}
+		})();
+		return () => {
+			canceled = true;
+		};
+	}, [forumId, normalizedHandle]);
+
+	const dimensionStyle: CSSProperties = useMemo(() => ({ width: size, height: size }), [size]);
+
+	if (url) {
+		return (
+			<img
+				src={url}
+				alt={alt || ''}
+				className={["forum-avatar", className].filter(Boolean).join(' ')}
+				style={{ ...dimensionStyle, ...style }}
+			/>
+		);
+	}
+
+	const initial = useMemo(() => {
+		if (alt && alt.trim()) return alt.trim().slice(0, 1).toUpperCase();
+		return '';
+	}, [alt]);
+
+	return (
+		<div
+			className={["forum-avatar", "placeholder", className].filter(Boolean).join(' ')}
+			style={{ ...dimensionStyle, ...style, display: 'inline-flex', alignItems: 'center', justifyContent: 'center', fontWeight: 700, color: 'var(--muted)', fontSize: Math.max(10, Math.floor(size * 0.42)) }}
+			aria-hidden={initial ? undefined : true}
+		>
+			{initial}
+		</div>
+	);
+}
+

--- a/src/components/ForumList.tsx
+++ b/src/components/ForumList.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useForumsStore } from '@state/forums';
+import ForumAvatar from '@components/ForumAvatar';
 
 export default function ForumList() {
 	const forums = useForumsStore((s) => s.forums);
@@ -42,6 +43,7 @@ export default function ForumList() {
 			<div className="list">
 				{items.map((f) => (
 					<div className="list-item" key={f.id} onClick={() => navigate(`/forum/${f.id}`)} style={{ position: 'relative' }}>
+						<ForumAvatar forumId={f.id} size={28} alt={(f.title ?? f.username ?? String(f.id)).toString()} />
 						<div className="col">
 							<div className="title">{f.title ?? (f.username ? `@${f.username}` : `Forum ${f.id}`)}</div>
 							<div className="sub">{f.isPublic ? 'Public' : 'Private'}{f.username ? ` • @${f.username}` : ''}</div>

--- a/src/features/catalog/FeaturedForums.tsx
+++ b/src/features/catalog/FeaturedForums.tsx
@@ -1,4 +1,5 @@
 import featured from './featured-forums.json';
+import ForumAvatar from '@components/ForumAvatar';
 
 interface FeaturedForum { address: string; name: string; description: string; }
 
@@ -10,7 +11,10 @@ export default function FeaturedForums({ onSelect }: { onSelect: (address: strin
 			<div className="gallery">
 				{items.map((f) => (
 					<div key={f.address} className="chiclet" onClick={() => onSelect(f.address)}>
-						<div className="title">{f.name}</div>
+						<div className="row" style={{ alignItems: 'center' }}>
+							<ForumAvatar address={f.address} size={28} alt={f.name} />
+							<div className="title">{f.name}</div>
+						</div>
 						<div className="sub">{f.address}</div>
 						<p style={{ margin: 0 }}>{f.description}</p>
 					</div>

--- a/src/features/forum/BoardPage.tsx
+++ b/src/features/forum/BoardPage.tsx
@@ -13,6 +13,7 @@ import { Api } from 'telegram';
 import { useUiStore } from '@state/ui';
 import SidebarToggle from '@components/SidebarToggle';
 import { formatTimeSince } from '@lib/time';
+import ForumAvatar from '@components/ForumAvatar';
 
 export default function BoardPage() {
 	const { id, boardId, threadId } = useParams();
@@ -426,6 +427,7 @@ export default function BoardPage() {
 				{!activeThreadId ? (
 					<div className="card" style={{ padding: 12 }}>
 						<div className="row" style={{ alignItems: 'center' }}>
+							<ForumAvatar forumId={forumId} size={28} alt={forumTitle} />
 							<h3 style={{ margin: 0 }}>
 								<Link to={`/forum/${forumId}`}>{forumTitle}</Link>
 								{' > '}
@@ -480,6 +482,7 @@ export default function BoardPage() {
 					<div className="card" style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
 						<div style={{ padding: 12, borderBottom: '1px solid var(--border)' }}>
 							<div className="row" style={{ alignItems: 'center' }}>
+								<ForumAvatar forumId={forumId} size={28} alt={forumTitle} />
 								<h3 style={{ margin: 0 }}>
 									<Link to={`/forum/${forumId}`}>{forumTitle}</Link>
 									{' > '}

--- a/src/features/forum/ForumPage.tsx
+++ b/src/features/forum/ForumPage.tsx
@@ -9,6 +9,7 @@ import { sendPlainMessage, deleteMessages } from '@lib/telegram/client';
 import { useUiStore } from '@state/ui';
 import SidebarToggle from '@components/SidebarToggle';
 import { formatTimeSince } from '@lib/time';
+import ForumAvatar from '@components/ForumAvatar';
 
 export default function ForumPage() {
 	const { id } = useParams();
@@ -104,7 +105,10 @@ export default function ForumPage() {
 			<SidebarToggle />
 			<main className="main">
 				<div className="card" style={{ padding: 12 }}>
-					<h3>{forumMeta?.title ?? (forumMeta?.username ? `@${forumMeta.username}` : `Forum ${forumId}`)}</h3>
+					<div className="row" style={{ alignItems: 'center' }}>
+						<ForumAvatar forumId={forumId} size={36} alt={forumMeta?.title ?? (forumMeta?.username ? `@${forumMeta.username}` : `Forum ${forumId}`)} />
+						<h3 style={{ margin: 0 }}>{forumMeta?.title ?? (forumMeta?.username ? `@${forumMeta.username}` : `Forum ${forumId}`)}</h3>
+					</div>
 					<div className="col">
 						<div className="row" style={{ alignItems: 'center' }}>
 							<h4 style={{ marginTop: 0, marginBottom: 0 }}>Boards</h4>

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -255,3 +255,7 @@ a:hover { text-decoration: underline; }
 .post-body { display: flex; flex-direction: column; gap: 8px; }
 .post-meta { color: var(--muted); font-size: 12px; }
 .post-content { font-size: 14px; }
+
+/* Forum avatars (circular) */
+.forum-avatar { border-radius: 999px; object-fit: cover; background: var(--avatar-bg); border: 1px solid var(--border); display: inline-block; overflow: hidden; }
+.forum-avatar.placeholder { opacity: 0.6; }


### PR DESCRIPTION
Add circular forum profile photos to four key UI locations to enhance visual integration.

---
<a href="https://cursor.com/background-agent?bcId=bc-0fc7c140-f1fb-4ebd-a3cf-baa2229c34d0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0fc7c140-f1fb-4ebd-a3cf-baa2229c34d0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

