### PR TITLE
Debug new posts not showing after pagination

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -52,6 +52,7 @@ export default function App() {
 				<Route path="/forum/:id" element={<RequireAuth><ForumPage /></RequireAuth>} />
 				<Route path="/forum/:id/board/:boardId" element={<RequireAuth><BoardPage /></RequireAuth>} />
 				<Route path="/forum/:id/board/:boardId/thread/:threadId" element={<RequireAuth><BoardPage /></RequireAuth>} />
+				<Route path="/forum/:id/board/:boardId/thread/:threadId/page/:page" element={<RequireAuth><BoardPage /></RequireAuth>} />
 				<Route path="/settings" element={<RequireAuth><SettingsPage /></RequireAuth>} />
 				<Route path="*" element={<RequireAuth><DiscoverPage /></RequireAuth>} />
 			</Routes>

--- a/src/features/forum/BoardPage.tsx
+++ b/src/features/forum/BoardPage.tsx
@@ -135,10 +135,9 @@ export default function BoardPage() {
 		queryKey: ['posts', forumId, boardId, activeThreadId, currentPage, pageSize, totalPostCount],
 		queryFn: async () => {
 			if (!activeThreadId) return [] as any[];
-			const N = totalPostCount || 0;
-			const addOffset = Math.max(0, (currentPage - 1) * pageSize);
+			const pagesFromLatest = Math.max(0, currentPage - 1);
 			const input = getInputPeerForForumId(forumId);
-			const items = await searchPostCardsSlice(input, String(activeThreadId), addOffset, pageSize);
+			const items = await (await import('@lib/protocol')).searchPostCardsPageByOffsetNew(input, String(activeThreadId), pagesFromLatest, pageSize);
 			// Build author map and load avatars once per unique user.
 			const uniqueUserIds = Array.from(new Set(items.map((p) => p.fromUserId).filter(Boolean))) as number[];
 			const client = await getClient();

--- a/src/features/forum/BoardPage.tsx
+++ b/src/features/forum/BoardPage.tsx
@@ -135,9 +135,12 @@ export default function BoardPage() {
 		queryKey: ['posts', forumId, boardId, activeThreadId, currentPage, pageSize, totalPostCount],
 		queryFn: async () => {
 			if (!activeThreadId) return [] as any[];
+			const N = totalPostCount || 0;
+			const pagesTotal = Math.max(1, Math.ceil((N || 0) / pageSize));
 			const pagesFromLatest = Math.max(0, currentPage - 1);
+			const exactLimit = currentPage === pagesTotal ? Math.max(1, N - pageSize * (pagesTotal - 1)) : pageSize;
 			const input = getInputPeerForForumId(forumId);
-			const items = await (await import('@lib/protocol')).searchPostCardsPageByOffsetNew(input, String(activeThreadId), pagesFromLatest, pageSize);
+			const items = await (await import('@lib/protocol')).searchPostCardsPageByOffsetNew(input, String(activeThreadId), pagesFromLatest, exactLimit);
 			// Build author map and load avatars once per unique user.
 			const uniqueUserIds = Array.from(new Set(items.map((p) => p.fromUserId).filter(Boolean))) as number[];
 			const client = await getClient();

--- a/src/features/forum/BoardPage.tsx
+++ b/src/features/forum/BoardPage.tsx
@@ -138,10 +138,12 @@ export default function BoardPage() {
 			const N = totalPostCount || 0;
 			const startIndex = (currentPage - 1) * pageSize;
 			const endExclusive = Math.min(startIndex + pageSize, Math.max(0, N));
-			const limit = Math.max(0, endExclusive - startIndex);
-			const addOffset = Math.max(0, N - endExclusive);
+			// If we're on the last page, always ask for full pageSize from the newest edge (addOffset=0)
+			const isLastPage = currentPage >= Math.max(1, Math.ceil((N || 0) / pageSize));
+			const effectiveLimit = isLastPage ? pageSize : Math.max(0, endExclusive - startIndex);
+			const effectiveAddOffset = isLastPage ? 0 : Math.max(0, N - endExclusive);
 			const input = getInputPeerForForumId(forumId);
-			const items = await searchPostCardsSlice(input, String(activeThreadId), addOffset, limit);
+			const items = await searchPostCardsSlice(input, String(activeThreadId), effectiveAddOffset, effectiveLimit);
 			// Build author map and load avatars once per unique user.
 			const uniqueUserIds = Array.from(new Set(items.map((p) => p.fromUserId).filter(Boolean))) as number[];
 			const client = await getClient();

--- a/src/lib/protocol.ts
+++ b/src/lib/protocol.ts
@@ -295,32 +295,27 @@ export async function searchPostCards(input: Api.TypeInputPeer, parentThreadId: 
 	return items;
 }
 
-/**
- * Efficiently counts the number of posts that belong to a thread using Telegram search.
- * Relies on MessagesSlice.count when available.
- */
 export async function countPostsForThread(input: Api.TypeInputPeer, parentThreadId: string): Promise<number> {
 	const client = await getClient();
-	const q = `fg.post ${parentThreadId}`;
-	// Use a tiny limit to get count metadata without transferring many messages
-	const res: any = await client.invoke(new Api.messages.Search({ peer: input, q, limit: 1, filter: new Api.InputMessagesFilterEmpty() }));
-	const count: number | undefined = (res && (res.count ?? res.total ?? res._count)) as any;
-	if (typeof count === 'number' && count >= 0) return count;
-	// Fallback: derive from returned messages length if count is unavailable
-	const msgs: any[] = (res?.messages ?? []).filter((m: any) => m.className === 'Message' || m._ === 'message');
-	// Filter to exact thread id matches
+	// Accurate count by scanning history; avoids relying on search index which can lag or miss items
+	let offsetId = 0;
+	const pageSize = 100;
+	let pages = 0;
 	let matched = 0;
-	for (const m of msgs) {
-		const parsed = parsePostCard(m.message ?? '');
-		if (parsed && parsed.parentThreadId === parentThreadId) matched++;
+	while (pages < 200) { // up to ~20k messages
+		const page: any = await client.invoke(new Api.messages.GetHistory({ peer: input, offsetId, addOffset: 0, limit: pageSize }));
+		const batch: any[] = (page.messages ?? []).filter((m: any) => m.className === 'Message' || m._ === 'message');
+		if (!batch.length) break;
+		for (const m of batch) {
+			const parsed = parsePostCard(m.message ?? '');
+			if (parsed && parsed.parentThreadId === parentThreadId) matched++;
+		}
+		offsetId = Number(batch[batch.length - 1].id);
+		pages++;
 	}
 	return matched;
 }
 
-/**
- * Fetches a slice of posts for a thread using Telegram search addOffset/limit.
- * The returned array is NOT guaranteed to be chronological; callers should sort by date.
- */
 export async function searchPostCardsSlice(
 	input: Api.TypeInputPeer,
 	parentThreadId: string,
@@ -364,6 +359,38 @@ export async function searchPostCardsSlice(
 				seenMsgIds.add(msgId);
 				items.push({ id: parsed.id, parentThreadId, messageId: msgId, fromUserId, user: fromUserId ? usersMap[String(fromUserId)] : undefined, date: Number(m.date), content: parsed.data.content, media: m.media, groupedId: m.groupedId ? String(m.groupedId) : undefined });
 				if (items.length >= Math.max(0, limit)) break;
+			}
+			offsetId = Number(batch[batch.length - 1].id);
+			pages++;
+		}
+	}
+	// Robust fallback for any page: scan history and simulate addOffset/limit over matching messages
+	if (items.length < Math.max(0, limit)) {
+		let offsetId = 0;
+		const pageSize = 100;
+		let pages = 0;
+		let matchedSoFar = 0;
+		const needed = Math.max(0, limit);
+		while (pages < 200 && items.length < needed) {
+			const page: any = await client.invoke(new Api.messages.GetHistory({ peer: input, offsetId, addOffset: 0, limit: pageSize }));
+			(page.users ?? []).forEach((u: any) => { usersMap[String(u.id)] = u; });
+			const batch: any[] = (page.messages ?? []).filter((m: any) => m.className === 'Message' || m._ === 'message');
+			if (!batch.length) break;
+			for (const m of batch) {
+				const msgId = Number(m.id);
+				if (seenMsgIds.has(msgId)) continue;
+				const parsed = parsePostCard(m.message ?? '');
+				if (!parsed) continue;
+				if (parsed.parentThreadId !== parentThreadId) continue;
+				// simulate addOffset: skip first addOffset matches, then collect up to limit
+				if (matchedSoFar < Math.max(0, addOffset)) {
+					matchedSoFar++;
+					continue;
+				}
+				const fromUserId: number | undefined = m.fromId?.userId ? Number(m.fromId.userId) : undefined;
+				seenMsgIds.add(msgId);
+				items.push({ id: parsed.id, parentThreadId, messageId: msgId, fromUserId, user: fromUserId ? usersMap[String(fromUserId)] : undefined, date: Number(m.date), content: parsed.data.content, media: m.media, groupedId: m.groupedId ? String(m.groupedId) : undefined });
+				if (items.length >= needed) break;
 			}
 			offsetId = Number(batch[batch.length - 1].id);
 			pages++;

--- a/src/lib/protocol.ts
+++ b/src/lib/protocol.ts
@@ -269,14 +269,11 @@ export async function searchPostCards(input: Api.TypeInputPeer, parentThreadId: 
 
 export async function countPostsForThread(input: Api.TypeInputPeer, parentThreadId: string): Promise<number> {
 	const client = await getClient();
-	const q = `fg.post ${parentThreadId}`;
-	// Use a tiny limit to get count metadata without transferring many messages
+	const q = `${parentThreadId}`;
 	const res: any = await client.invoke(new Api.messages.Search({ peer: input, q, limit: 1, filter: new Api.InputMessagesFilterEmpty() }));
 	const count: number | undefined = (res && (res.count ?? res.total ?? res._count)) as any;
 	if (typeof count === 'number' && count >= 0) return count;
-	// Fallback: derive from returned messages length if count is unavailable
 	const msgs: any[] = (res?.messages ?? []).filter((m: any) => m.className === 'Message' || m._ === 'message');
-	// Filter to exact thread id matches
 	let matched = 0;
 	for (const m of msgs) {
 		const parsed = parsePostCard(m.message ?? '');
@@ -403,6 +400,38 @@ export async function searchPostCardsPageByOffset(
 		offsetId = Number(messagesStep[messagesStep.length - 1].id);
 	}
 	// fetch the target page
+	const res: any = await client.invoke(new Api.messages.Search({ peer: input, q, limit: Math.max(1, pageSize), offsetId, addOffset: 0, filter: new Api.InputMessagesFilterEmpty() }));
+	(res.users ?? []).forEach((u: any) => { usersMap[String(u.id)] = u; });
+	const items: PostCard[] = [];
+	const messages: any[] = (res.messages ?? []).filter((m: any) => m.className === 'Message' || m._ === 'message');
+	for (const m of messages) {
+		const parsed = parsePostCard(m.message ?? '');
+		if (!parsed) continue;
+		if (parsed.parentThreadId !== parentThreadId) continue;
+		const fromUserId: number | undefined = m.fromId?.userId ? Number(m.fromId.userId) : undefined;
+		const msgId = Number(m.id);
+		items.push({ id: parsed.id, parentThreadId, messageId: msgId, fromUserId, user: fromUserId ? usersMap[String(fromUserId)] : undefined, date: Number(m.date), content: parsed.data.content, media: m.media, groupedId: m.groupedId ? String(m.groupedId) : undefined });
+	}
+	return items;
+}
+
+export async function searchPostCardsPageByOffsetNew(
+	input: Api.TypeInputPeer,
+	parentThreadId: string,
+	pagesFromLatest: number,
+	pageSize: number,
+): Promise<PostCard[]> {
+	const client = await getClient();
+	const usersMap: Record<string, any> = {};
+	let offsetId = 0;
+	const q = `${parentThreadId}`;
+	for (let step = 0; step < Math.max(0, pagesFromLatest); step++) {
+		const resStep: any = await client.invoke(new Api.messages.Search({ peer: input, q, limit: Math.max(1, pageSize), offsetId, addOffset: 0, filter: new Api.InputMessagesFilterEmpty() }));
+		(resStep.users ?? []).forEach((u: any) => { usersMap[String(u.id)] = u; });
+		const messagesStep: any[] = (resStep.messages ?? []).filter((m: any) => m.className === 'Message' || m._ === 'message');
+		if (!messagesStep.length) break;
+		offsetId = Number(messagesStep[messagesStep.length - 1].id);
+	}
 	const res: any = await client.invoke(new Api.messages.Search({ peer: input, q, limit: Math.max(1, pageSize), offsetId, addOffset: 0, filter: new Api.InputMessagesFilterEmpty() }));
 	(res.users ?? []).forEach((u: any) => { usersMap[String(u.id)] = u; });
 	const items: PostCard[] = [];


### PR DESCRIPTION
Add `GetHistory` fallback for latest posts and adjust last page fetch logic to ensure new posts appear immediately.

New posts were not showing due to Telegram search indexing lag when using `messages.search` for pagination. This change ensures the UI fetches the freshest posts by merging results from `messages.getHistory` and always requesting the latest page from the top.

---
<a href="https://cursor.com/background-agent?bcId=bc-e0ed82e2-e90c-4864-8910-30136d56f565">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e0ed82e2-e90c-4864-8910-30136d56f565">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

