### PR TITLE
Format inline code blocks correctly

### DIFF
--- a/src/lib/markdown.tsx
+++ b/src/lib/markdown.tsx
@@ -63,7 +63,7 @@ export default function MarkdownView({ text, className }: MarkdownViewProps) {
 							const codeText = String(children ?? '');
 							const hasNewline = codeText.includes('\n');
 							const hasLanguage = Boolean(match && match[1]);
-							if (inline || (!hasLanguage && !hasNewline)) {
+							if (inline || !hasNewline) {
 								return (
 									<code className="inline-code" {...props}>{children}</code>
 								);

--- a/src/lib/markdown.tsx
+++ b/src/lib/markdown.tsx
@@ -58,19 +58,18 @@ export default function MarkdownView({ text, className }: MarkdownViewProps) {
 				rehypePlugins={rehypePlugins}
 				remarkPlugins={[remarkGfm, remarkMath]}
 									components={{
-												code({ node, inline, className, children, ...props }: any) {
+						pre({ children }: any) {
+							const child = Array.isArray(children) ? children[0] : children;
+							const childProps: any = (child as any)?.props || {};
+							const className: string = childProps.className || '';
 							const match = /language-([\w-]+)/.exec(className || '');
-							if (inline) {
-								return (
-									<code className="inline-code" {...props}>{children}</code>
-								);
-							}
 							const language = match?.[1] || 'text';
+							const codeChildren = childProps.children;
 							return (
 								<div className="code-block">
 									<div className="code-lang">{language}</div>
 									<pre className={className}>
-										<code className={className} {...props}>{children}</code>
+										<code className={className}>{codeChildren}</code>
 									</pre>
 								</div>
 							);

--- a/src/lib/markdown.tsx
+++ b/src/lib/markdown.tsx
@@ -37,7 +37,7 @@ export default function MarkdownView({ text, className }: MarkdownViewProps) {
 			code: [
 				...((defaultSchema as any).attributes?.code || []),
 				// allow language and hljs classes on code.
-				['className', 'hljs', /^language[-_a-z0-9]+$/]
+				['className', 'hljs', /^language[-_a-z0-9]+$/, 'inline-code']
 			],
 			pre: [
 				...((defaultSchema as any).attributes?.pre || []),
@@ -57,17 +57,17 @@ export default function MarkdownView({ text, className }: MarkdownViewProps) {
 			<ReactMarkdown
 				rehypePlugins={rehypePlugins}
 				remarkPlugins={[remarkGfm, remarkMath]}
-				components={{
-					code({ node, inline, className, children, ...props }: any) {
-						const match = /language-([\w-]+)/.exec(className || '');
-						if (inline) {
+									components={{
+						code({ node, inline, className, children, ...props }: any) {
+							const match = /language-([\w-]+)/.exec(className || '');
+							if (inline) {
+								return (
+									<code className="inline-code" {...props}>{children}</code>
+								);
+							}
+							const language = match?.[1] || 'text';
 							return (
-								<code className={className} {...props}>{children}</code>
-							);
-						}
-						const language = match?.[1] || 'text';
-						return (
-							<div className="code-block">
+<div className="code-block">
 								<div className="code-lang">{language}</div>
 								<pre className={className}>
 									<code className={className} {...props}>{children}</code>

--- a/src/lib/markdown.tsx
+++ b/src/lib/markdown.tsx
@@ -58,23 +58,26 @@ export default function MarkdownView({ text, className }: MarkdownViewProps) {
 				rehypePlugins={rehypePlugins}
 				remarkPlugins={[remarkGfm, remarkMath]}
 									components={{
-						code({ node, inline, className, children, ...props }: any) {
+												code({ node, inline, className, children, ...props }: any) {
 							const match = /language-([\w-]+)/.exec(className || '');
-							if (inline) {
+							const codeText = String(children ?? '');
+							const hasNewline = codeText.includes('\n');
+							const hasLanguage = Boolean(match && match[1]);
+							if (inline || (!hasLanguage && !hasNewline)) {
 								return (
 									<code className="inline-code" {...props}>{children}</code>
 								);
 							}
 							const language = match?.[1] || 'text';
 							return (
-<div className="code-block">
-								<div className="code-lang">{language}</div>
-								<pre className={className}>
-									<code className={className} {...props}>{children}</code>
-								</pre>
-							</div>
-						);
-					},
+								<div className="code-block">
+									<div className="code-lang">{language}</div>
+									<pre className={className}>
+										<code className={className} {...props}>{children}</code>
+									</pre>
+								</div>
+							);
+						},
 					img({ node, ...props }: any) {
 						const style = {
 							maxWidth: `${imageMaxWidthPx}px`,

--- a/src/lib/markdown.tsx
+++ b/src/lib/markdown.tsx
@@ -60,10 +60,7 @@ export default function MarkdownView({ text, className }: MarkdownViewProps) {
 									components={{
 												code({ node, inline, className, children, ...props }: any) {
 							const match = /language-([\w-]+)/.exec(className || '');
-							const codeText = String(children ?? '');
-							const hasNewline = codeText.includes('\n');
-							const hasLanguage = Boolean(match && match[1]);
-							if (inline || !hasNewline) {
+							if (inline) {
 								return (
 									<code className="inline-code" {...props}>{children}</code>
 								);

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -225,8 +225,7 @@ a:hover { text-decoration: underline; }
 /* Markdown defaults */
 .md :where(h1,h2,h3,h4) { margin: 12px 0 8px; }
 .md :where(p,ul,ol) { margin: 8px 0; }
-.md code { background: var(--code-bg); border: 1px solid var(--border); padding: 1px 4px; border-radius: 6px; }
-.md code.inline-code { display: inline; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; color: var(--muted); background: transparent; border: 0; padding: 0 3px; font-style: normal; font-weight: normal; text-decoration: none; }
+.md :not(pre) > code { display: inline; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; color: var(--muted); background: transparent; border: 0; padding: 0 3px; font-style: normal; font-weight: normal; text-decoration: none; }
 .md pre { background: var(--code-bg); border: 1px solid var(--border); padding: 8px; border-radius: 10px; overflow: auto; }
 
 /* Code block wrapper with language header */

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -226,6 +226,7 @@ a:hover { text-decoration: underline; }
 .md :where(h1,h2,h3,h4) { margin: 12px 0 8px; }
 .md :where(p,ul,ol) { margin: 8px 0; }
 .md code { background: var(--code-bg); border: 1px solid var(--border); padding: 1px 4px; border-radius: 6px; }
+.md code.inline-code { display: inline; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; color: var(--muted); background: transparent; border: 0; padding: 0 3px; font-style: normal; font-weight: normal; text-decoration: none; }
 .md pre { background: var(--code-bg); border: 1px solid var(--border); padding: 8px; border-radius: 10px; overflow: auto; }
 
 /* Code block wrapper with language header */


### PR DESCRIPTION
Render inline code blocks as in-paragraph text with a monospace font and muted color, preventing block-level styling and markdown emphasis.

---
<a href="https://cursor.com/background-agent?bcId=bc-2be70414-5d2d-4afc-8f6f-c5cf2639bbcd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2be70414-5d2d-4afc-8f6f-c5cf2639bbcd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

