### PR TITLE
Ensure code block colors adapt to theme

### DIFF
--- a/src/lib/markdown.tsx
+++ b/src/lib/markdown.tsx
@@ -6,7 +6,6 @@ import rehypeHighlight from 'rehype-highlight';
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
 import { useSettingsStore } from '@state/settings';
 import 'katex/dist/katex.min.css';
-import 'highlight.js/styles/github-dark.css';
 
 interface MarkdownViewProps {
 	text: string;
@@ -16,7 +15,16 @@ interface MarkdownViewProps {
 export default function MarkdownView({ text, className }: MarkdownViewProps) {
 	const { markdownEnabled, katexEnabled, imageMaxWidthPx } = useSettingsStore();
 	if (!markdownEnabled) {
-		return <pre className={className}>{text}</pre>;
+		return (
+			<div className={`md ${className ?? ''}`}>
+				<div className="code-block">
+					<div className="code-lang">text</div>
+					<pre>
+						<code>{text}</code>
+					</pre>
+				</div>
+			</div>
+		);
 	}
 	// Preserve math classes through sanitization so rehype-katex can detect them.
 	const sanitizeOptions: any = {


### PR DESCRIPTION
Ensure code block backgrounds are theme-dependent by removing conflicting highlight.js CSS and applying `code-block` styling to non-markdown text.

---
<a href="https://cursor.com/background-agent?bcId=bc-c03cbd13-204f-4824-85c2-bba914b44e82">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c03cbd13-204f-4824-85c2-bba914b44e82">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

