### PR TITLE
Version ForumGram card protocol

### DIFF
--- a/src/lib/protocol-versioned.ts
+++ b/src/lib/protocol-versioned.ts
@@ -1,0 +1,83 @@
+import * as legacy from './protocol';
+
+export * from './protocol-pagination';
+
+export const LEGACY_PROTOCOL_VERSION = 0 as const;
+export const CURRENT_PROTOCOL_VERSION = 1 as const;
+export type ProtocolVersion = typeof LEGACY_PROTOCOL_VERSION | typeof CURRENT_PROTOCOL_VERSION;
+
+export interface ParsedBoardCard {
+	version: ProtocolVersion;
+	id: string;
+	data: { title: string; description?: string };
+}
+
+export interface ParsedThreadCard {
+	version: ProtocolVersion;
+	id: string;
+	parentBoardId: string;
+	data: { title: string };
+}
+
+export interface ParsedPostCard {
+	version: ProtocolVersion;
+	id: string;
+	parentThreadId: string;
+	data: { content: string };
+}
+
+function addCurrentVersion(card: string, payloadLineIndex: number): string {
+	const lines = card.split(/\n/);
+	const payload = JSON.parse(lines.slice(payloadLineIndex).join('\n')) as Record<string, unknown>;
+	return [
+		...lines.slice(0, payloadLineIndex),
+		JSON.stringify({ version: CURRENT_PROTOCOL_VERSION, ...payload }),
+	].join('\n');
+}
+
+function readProtocolVersion(text: string, payloadLineIndex: number): ProtocolVersion | null {
+	const lines = (text ?? '').split(/\n/);
+	try {
+		const payload: unknown = JSON.parse(lines.slice(payloadLineIndex).join('\n'));
+		if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return null;
+		if (!Object.prototype.hasOwnProperty.call(payload, 'version')) return LEGACY_PROTOCOL_VERSION;
+		return (payload as { version?: unknown }).version === CURRENT_PROTOCOL_VERSION
+			? CURRENT_PROTOCOL_VERSION
+			: null;
+	} catch {
+		return null;
+	}
+}
+
+export function composeBoardCard(id: string, data: { title: string; description?: string }): string {
+	return addCurrentVersion(legacy.composeBoardCard(id, data), 2);
+}
+
+export function parseBoardCard(text: string): ParsedBoardCard | null {
+	const version = readProtocolVersion(text, 2);
+	if (version === null) return null;
+	const parsed = legacy.parseBoardCard(text);
+	return parsed ? { version, ...parsed } : null;
+}
+
+export function composeThreadCard(id: string, parentBoardId: string, data: { title: string }): string {
+	return addCurrentVersion(legacy.composeThreadCard(id, parentBoardId, data), 3);
+}
+
+export function parseThreadCard(text: string): ParsedThreadCard | null {
+	const version = readProtocolVersion(text, 3);
+	if (version === null) return null;
+	const parsed = legacy.parseThreadCard(text);
+	return parsed ? { version, ...parsed } : null;
+}
+
+export function composePostCard(id: string, parentThreadId: string, data: { content: string }): string {
+	return addCurrentVersion(legacy.composePostCard(id, parentThreadId, data), 3);
+}
+
+export function parsePostCard(text: string): ParsedPostCard | null {
+	const version = readProtocolVersion(text, 3);
+	if (version === null) return null;
+	const parsed = legacy.parsePostCard(text);
+	return parsed ? { version, ...parsed } : null;
+}

--- a/src/lib/protocol-versioning.test.ts
+++ b/src/lib/protocol-versioning.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { parsePostCard as parseLegacyPostCard } from './protocol';
+import {
+	CURRENT_PROTOCOL_VERSION,
+	LEGACY_PROTOCOL_VERSION,
+	composeBoardCard,
+	composePostCard,
+	composeThreadCard,
+	parseBoardCard,
+	parsePostCard,
+	parseThreadCard,
+} from './protocol-versioned';
+
+describe('ForumGram card protocol versioning', () => {
+	it('writes version 1 into every new card payload', () => {
+		const boardPayload = JSON.parse(composeBoardCard('board-id', { title: 'Board' }).split('\n').slice(2).join('\n'));
+		const threadPayload = JSON.parse(composeThreadCard('thread-id', 'board-id', { title: 'Thread' }).split('\n').slice(3).join('\n'));
+		const postPayload = JSON.parse(composePostCard('post-id', 'thread-id', { content: 'Post' }).split('\n').slice(3).join('\n'));
+
+		expect(boardPayload.version).toBe(CURRENT_PROTOCOL_VERSION);
+		expect(threadPayload.version).toBe(CURRENT_PROTOCOL_VERSION);
+		expect(postPayload.version).toBe(CURRENT_PROTOCOL_VERSION);
+	});
+
+	it('reports new cards as version 1', () => {
+		expect(parseBoardCard(composeBoardCard('board-id', { title: 'Board' }))?.version).toBe(CURRENT_PROTOCOL_VERSION);
+		expect(parseThreadCard(composeThreadCard('thread-id', 'board-id', { title: 'Thread' }))?.version).toBe(CURRENT_PROTOCOL_VERSION);
+		expect(parsePostCard(composePostCard('post-id', 'thread-id', { content: 'Post' }))?.version).toBe(CURRENT_PROTOCOL_VERSION);
+	});
+
+	it('continues to read unlabeled cards as version 0', () => {
+		const boardV0 = 'fg.metadata.board\nboard-id\n{"title":"Board","description":""}';
+		const threadV0 = 'fg.metadata.thread\nthread-id\nparent:board-id\n{"title":"Thread"}';
+		const postV0 = 'fg.post\npost-id\nparent:thread-id\n{"content":"Post"}';
+
+		expect(parseBoardCard(boardV0)?.version).toBe(LEGACY_PROTOCOL_VERSION);
+		expect(parseThreadCard(threadV0)?.version).toBe(LEGACY_PROTOCOL_VERSION);
+		expect(parsePostCard(postV0)?.version).toBe(LEGACY_PROTOCOL_VERSION);
+	});
+
+	it('keeps version 1 post payloads readable by the version 0 parser', () => {
+		const card = composePostCard('post-id', 'thread-id', { content: '```ts\nconst x = 1;\n```' });
+		expect(parseLegacyPostCard(card)?.data.content).toBe('```ts\nconst x = 1;\n```');
+	});
+
+	it('rejects explicitly unsupported protocol versions', () => {
+		const unsupported = 'fg.post\npost-id\nparent:thread-id\n{"version":2,"content":"Post"}';
+		expect(parsePostCard(unsupported)).toBeNull();
+	});
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,7 @@
       "@app/*": ["src/app/*"],
       "@components/*": ["src/components/*"],
       "@features/*": ["src/features/*"],
-      "@lib/protocol": ["src/lib/protocol-pagination.ts"],
+      "@lib/protocol": ["src/lib/protocol-versioned.ts"],
       "@lib/*": ["src/lib/*"],
       "@state/*": ["src/state/*"],
       "@workers/*": ["src/workers/*"],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -55,7 +55,7 @@ export default defineConfig({
 			'@app': r('./src/app'),
 			'@components': r('./src/components'),
 			'@features': r('./src/features'),
-			'@lib/protocol': r('./src/lib/protocol-pagination.ts'),
+			'@lib/protocol': r('./src/lib/protocol-versioned.ts'),
 			'@lib': r('./src/lib'),
 			'@state': r('./src/state'),
 			'@workers': r('./src/workers'),


### PR DESCRIPTION
## Changes
- Emit `version: 1` in the JSON payload of newly composed board, thread, and post cards.
- Treat existing unlabeled cards as protocol version 0 without rewriting them.
- Return the detected version from the version-aware parsers and reject unsupported explicit versions.
- Preserve the existing card envelope and payload fields so legacy readers and Telegram search/pagination remain compatible.
- Add compatibility and round-trip tests.

## Validation
- TypeScript facade compiled against the existing protocol signatures locally.
- Focused version detection and payload compatibility checks passed locally.