### PR TITLE
Remove protocol upgrade helper

### DIFF
--- a/src/lib/protocol-versioning.test.ts
+++ b/src/lib/protocol-versioning.test.ts
@@ -12,7 +12,6 @@ import {
 	parseThreadCard,
 	postCardFromTelegramMessage,
 	threadMetaFromTelegramMessage,
-	upgradeCardToCurrent,
 } from './protocol';
 import { GOLDEN_CARDS } from './protocol/golden-fixtures';
 
@@ -56,13 +55,5 @@ describe('ForumGram card protocol dispatcher', () => {
 		expect(boardMetaFromTelegramMessage(telegramMessage(GOLDEN_CARDS.unsupported.board))).toBeNull();
 		expect(threadMetaFromTelegramMessage(telegramMessage(GOLDEN_CARDS.unsupported.thread))).toBeNull();
 		expect(postCardFromTelegramMessage(telegramMessage(GOLDEN_CARDS.unsupported.post))).toBeNull();
-	});
-
-	it('upgrades version 0 cards without mutating current cards', () => {
-		expect(upgradeCardToCurrent(GOLDEN_CARDS.v0.board)).toBe(GOLDEN_CARDS.v1.board);
-		expect(upgradeCardToCurrent(GOLDEN_CARDS.v0.thread)).toBe(GOLDEN_CARDS.v1.thread);
-		expect(upgradeCardToCurrent(GOLDEN_CARDS.v0.post)).toBe(GOLDEN_CARDS.v1.post);
-		expect(upgradeCardToCurrent(GOLDEN_CARDS.v1.post)).toBe(GOLDEN_CARDS.v1.post);
-		expect(upgradeCardToCurrent(GOLDEN_CARDS.unsupported.post)).toBeNull();
 	});
 });

--- a/src/lib/protocol/codec.ts
+++ b/src/lib/protocol/codec.ts
@@ -64,19 +64,3 @@ export function parsePostCard(text: string): ParsedPostCard | null {
 export function getCardProtocolVersion(text: string): ProtocolVersion | null {
 	return parseCard(text)?.version ?? null;
 }
-
-/** Return a version 1 representation without writing it back to Telegram. */
-export function upgradeCardToCurrent(text: string): string | null {
-	const parsed = parseCard(text);
-	if (!parsed) return null;
-	if (parsed.version === CURRENT_PROTOCOL_VERSION) return text;
-
-	switch (parsed.kind) {
-		case 'board':
-			return composeBoardCard(parsed.id, parsed.data);
-		case 'thread':
-			return composeThreadCard(parsed.id, parsed.parentBoardId, parsed.data);
-		case 'post':
-			return composePostCard(parsed.id, parsed.parentThreadId, parsed.data);
-	}
-}


### PR DESCRIPTION
Remove the unused `upgradeCardToCurrent()` function and its test. Version 0 remains readable, version 1 remains the only emitted format, and no migration API is exposed.